### PR TITLE
osl_scop_remove_unions functionality

### DIFF
--- a/include/osl/scop.h.in
+++ b/include/osl/scop.h.in
@@ -141,6 +141,7 @@ void       osl_scop_free(osl_scop_p);
 void       osl_scop_add(osl_scop_p *, osl_scop_p);
 size_t     osl_scop_number(osl_scop_p);
 osl_scop_p osl_scop_clone(osl_scop_p);
+osl_scop_p osl_scop_remove_unions(osl_scop_p);
 int        osl_scop_equal(osl_scop_p, osl_scop_p);
 int        osl_scop_integrity_check(osl_scop_p);
 int        osl_scop_check_compatible_scoplib(osl_scop_p);

--- a/include/osl/statement.h
+++ b/include/osl/statement.h
@@ -132,6 +132,7 @@ void            osl_statement_compact(osl_statement_p, int);
 int             osl_statement_number(osl_statement_p);
 osl_statement_p osl_statement_nclone(osl_statement_p, int);
 osl_statement_p osl_statement_clone(osl_statement_p);
+osl_statement_p osl_statement_remove_unions(osl_statement_p);
 int             osl_statement_equal(osl_statement_p, osl_statement_p);
 int             osl_statement_integrity_check(osl_statement_p, int);
 int             osl_statement_get_nb_iterators(osl_statement_p);

--- a/source/scop.c
+++ b/source/scop.c
@@ -663,6 +663,53 @@ osl_scop_p osl_scop_clone(osl_scop_p scop) {
   return clone;
 }
 
+/**
+ * osl_scop_remove_unions function:
+ * Replace each statement having unions of relations by a list of statements,
+ * each of which has exactly one domain relation and one scattering relation.
+ * \param[in] scop A SCoP with statements featuring unions of relations.
+ * \returns  An identical SCoP without unions of relations.
+ */
+osl_scop_p osl_scop_remove_unions(osl_scop_p scop) {
+  osl_statement_p statement, new_statement, scop_statement_ptr;
+  osl_scop_p new_scop, scop_ptr, result = NULL;
+
+  for ( ; scop != NULL; scop = scop->next) {
+    statement = scop->statement;
+    scop_statement_ptr = NULL;
+    new_scop = osl_scop_malloc();
+
+    for ( ; statement != NULL; statement = statement->next) {
+      new_statement = osl_statement_remove_unions(statement);
+      if (!scop_statement_ptr) {
+        scop_statement_ptr = new_statement;
+        new_scop->statement = scop_statement_ptr;
+      } else {
+        scop_statement_ptr->next = new_statement;
+        scop_statement_ptr = scop_statement_ptr->next;
+      }
+    }
+
+    new_scop->context = osl_relation_clone(scop->context);
+    new_scop->extension = osl_generic_clone(scop->extension);
+    if (scop->language != NULL) {
+      new_scop->language = (char *) malloc(strlen(scop->language) + 1);
+      new_scop->language = strcpy(new_scop->language, scop->language);
+    }
+    new_scop->parameters = osl_generic_clone(scop->parameters);
+    new_scop->registry = osl_interface_clone(scop->registry);
+    new_scop->version = scop->version;
+    if (!result) {
+      result = new_scop;
+      scop_ptr = new_scop;
+    } else {
+      scop_ptr->next = new_scop;
+      scop_ptr = scop_ptr->next;
+    }
+  }
+
+  return result;
+}
 
 /**
  * osl_scop_equal function:

--- a/source/statement.c
+++ b/source/statement.c
@@ -629,6 +629,61 @@ osl_statement_p osl_statement_clone(osl_statement_p statement) {
   return osl_statement_nclone(statement, -1);
 }
 
+/// Clone first part of the union, return NULL if input is NULL.
+static osl_relation_p osl_relation_clone_one_safe(osl_relation_p relation) {
+  if (relation == NULL)
+    return NULL;
+  return osl_relation_nclone(relation, 1);
+}
+
+/**
+ * osl_statement_remove_unions function:
+ * Create a statement list from a statement containing unions of relations in
+ * domain and/or scattering.  This functions constructs multiple new statements
+ * and keeps the original statement intact.  Each new statement has exactly one
+ * domain union component and exactly one scattering union component.  If the
+ * statement does not have the domain relation or the scattering relation, this
+ * function returns \c NULL.
+ * \param[in] statement A pointer to the statement
+ * \return    A pointer to the head of the newly created statement list.
+ */
+osl_statement_p osl_statement_remove_unions(osl_statement_p statement) {
+  osl_relation_p domain, scattering;
+  osl_statement_p statement_ptr, result;
+  if (!statement)
+    return NULL;
+
+  // Make at least one new statement, even if there are no relations.
+  domain = statement->domain;
+  scattering = statement->scattering;
+  result = NULL;
+  do {
+    do {
+      osl_statement_p new_statement = osl_statement_malloc();
+      new_statement->domain = osl_relation_clone_one_safe(domain);
+      new_statement->scattering = osl_relation_clone_one_safe(scattering);
+      new_statement->access = osl_relation_list_clone(statement->access);
+      new_statement->extension = osl_generic_clone(statement->extension);
+      if (!result) {
+        statement_ptr = new_statement;
+        result = new_statement;
+      } else {
+        statement_ptr->next = new_statement;
+        statement_ptr = statement_ptr->next;
+      }
+      if (scattering == NULL || scattering->next == NULL)
+        break;
+      scattering = scattering->next;
+    } while (1);
+    if (domain == NULL || domain->next == NULL)
+      break;
+    domain = domain->next;
+  } while (1);
+
+  return result;
+}
+
+
 
 /**
  * osl_statement_equal function:


### PR DESCRIPTION
Replace a statement with unions of relations in domain or scattering by a list of equivalent statements, each of which has at most one domain relation and at most one scattering relation.

This functionality is support for legacy tools e.g. Candl or openscop<->scoplib conversion.