### PR TITLE
Main scripts fail on error

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
-autoreconf -i
+
+set -e
+
+# (Re)Generate autotools files
+autoreconf -vi

--- a/include/osl/extensions/loop.h
+++ b/include/osl/extensions/loop.h
@@ -94,7 +94,7 @@ extern "C"
  */
 struct osl_loop {
   char * iter;              /**< \brief \0 terminated iterator name */
-  size_t    nb_stmts;          /**< \brief Number of statements in the loop */
+  size_t nb_stmts;          /**< \brief Number of statements in the loop */
   int  * stmt_ids;          /**< \brief Array of statement identifiers. */
   char * private_vars;      /**< \brief \0 terminated variable names */
   int    directive;         /**< \brief Loop directive to implement */

--- a/redo.sh
+++ b/redo.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
+
+set -e
+
 make maintainer-clean
 ./autogen.sh
-./configure --prefix=$HOME/usr --with-gmp=system --with-gmp-prefix=/usr
+./configure --prefix="$HOME"/usr --with-gmp=system --with-gmp-prefix=/usr
 make


### PR DESCRIPTION
Minor PR to make `autogen.sh` and `redo.sh` scripts fail on any error.
Correctly indent declaration statement on `loop.h` class. 